### PR TITLE
Assume empty metadata when absent

### DIFF
--- a/src/main/kotlin/com/jakewharton/plex/plex.kt
+++ b/src/main/kotlin/com/jakewharton/plex/plex.kt
@@ -113,7 +113,7 @@ private data class PlexSections(
 @Serializable
 private data class PlexMetadataList(
 	@SerialName("Metadata")
-	val metadata: List<PlexMetadata>,
+	val metadata: List<PlexMetadata> = emptyList(), // Will be absent from JSON if no content.
 )
 
 @Serializable


### PR DESCRIPTION
This occurs when a library has zero content.

Closes #8